### PR TITLE
Do not post in deprecated references.yml file when a file is only being renamed

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    danger-packwerk (0.3.0)
+    danger-packwerk (0.4.0)
       danger-plugin-api (~> 1.0)
       packwerk
       parse_packwerk
@@ -44,7 +44,7 @@ GEM
     cork (0.3.0)
       colored2 (~> 3.1)
     crass (1.0.6)
-    danger (8.6.1)
+    danger (9.0.0)
       claide (~> 1.0)
       claide-plugins (>= 0.9.2)
       colored2 (~> 3.1)
@@ -55,14 +55,14 @@ GEM
       kramdown (~> 2.3)
       kramdown-parser-gfm (~> 1.0)
       no_proxy_fix
-      octokit (~> 4.7)
+      octokit (~> 5.0)
       terminal-table (>= 1, < 4)
     danger-plugin-api (1.0.0)
       danger (> 2.0)
     diff-lcs (1.5.0)
     digest (3.1.0)
     erubi (1.11.0)
-    faraday (1.10.1)
+    faraday (1.10.2)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)
@@ -108,7 +108,7 @@ GEM
     nokogiri (1.13.8)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
-    octokit (4.25.1)
+    octokit (5.4.0)
       faraday (>= 1, < 3)
       sawyer (~> 0.9)
     open4 (1.3.4)

--- a/lib/danger-packwerk/danger_deprecated_references_yml_changes.rb
+++ b/lib/danger-packwerk/danger_deprecated_references_yml_changes.rb
@@ -45,7 +45,14 @@ module DangerPackwerk
 
       current_comment_count = 0
 
-      violation_diff.added_violations.group_by(&:class_name).each do |_class_name, violations|
+      # The format for git.renamed_files is a T::Array[{after: "some/path/new", before: "some/path/old"}]
+      renamed_files = git.renamed_files.map { |before_after_file| before_after_file[:after] }
+
+      violations_to_comment_on = violation_diff.added_violations.reject do |violation|
+        renamed_files.include?(violation.file)
+      end
+
+      violations_to_comment_on.group_by(&:class_name).each do |_class_name, violations|
         break if current_comment_count >= max_comments
 
         location = T.must(violations.first).file_location

--- a/lib/danger-packwerk/version.rb
+++ b/lib/danger-packwerk/version.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 module DangerPackwerk
-  VERSION = '0.3.0'
+  VERSION = '0.4.0'
 end

--- a/spec/danger_packwerk/danger_deprecated_references_yml_changes_spec.rb
+++ b/spec/danger_packwerk/danger_deprecated_references_yml_changes_spec.rb
@@ -175,7 +175,7 @@ module DangerPackwerk
         end
       end
 
-      context 'a deprecated_refrences.yml file is modified to remove some, but not all, violations' do
+      context 'a deprecated_references.yml file is modified to remove some, but not all, violations' do
         let(:modified_files) do
           [
             write_file('packs/some_pack/deprecated_references.yml', <<~YML.strip)
@@ -223,7 +223,7 @@ module DangerPackwerk
         end
       end
 
-      context 'a deprecated_refrences.yml file is modified to add a new violation against a new constant in an existing file' do
+      context 'a deprecated_references.yml file is modified to add a new violation against a new constant in an existing file' do
         let(:modified_files) do
           [
             write_file('packs/some_pack/deprecated_references.yml', <<~YML.strip)
@@ -292,7 +292,7 @@ module DangerPackwerk
         end
       end
 
-      context 'a deprecated_refrences.yml file is modified to add a new reference against an existing constant in an existing file' do
+      context 'a deprecated_references.yml file is modified to add a new reference against an existing constant in an existing file' do
         let(:modified_files) do
           [
             write_file('packs/some_pack/deprecated_references.yml', <<~YML.strip)
@@ -351,7 +351,7 @@ module DangerPackwerk
         end
       end
 
-      context 'a deprecated_refrences.yml file is modified to add another violation on a file with an existing violation' do
+      context 'a deprecated_references.yml file is modified to add another violation on a file with an existing violation' do
         let(:modified_files) do
           [
             write_file('packs/some_pack/deprecated_references.yml', <<~YML.strip)
@@ -428,7 +428,7 @@ module DangerPackwerk
         end
       end
 
-      context 'a deprecated_refrences.yml file is modified to add another violation on a file with an existing violation, and the constants have clashing names' do
+      context 'a deprecated_references.yml file is modified to add another violation on a file with an existing violation, and the constants have clashing names' do
         let(:modified_files) do
           [
             write_file('packs/some_pack/deprecated_references.yml', <<~YML.strip)
@@ -505,7 +505,7 @@ module DangerPackwerk
         end
       end
 
-      context 'a deprecated_refrences.yml file is modified to change violations in many files' do
+      context 'a deprecated_references.yml file is modified to change violations in many files' do
         let(:modified_files) do
           [
             write_file('packs/some_pack/deprecated_references.yml', <<~YML.strip)
@@ -582,7 +582,7 @@ module DangerPackwerk
         end
       end
 
-      context 'a deprecated_refrences.yml file is modified to add 30 and remove 15 violations' do
+      context 'a deprecated_references.yml file is modified to add 30 and remove 15 violations' do
         let(:modified_files) do
           [
             write_file('packs/some_pack/deprecated_references.yml', <<~YML.strip)
@@ -703,7 +703,7 @@ module DangerPackwerk
         end
       end
 
-      context 'a deprecated_refrences.yml file using single quotes is modified' do
+      context 'a deprecated_references.yml file using single quotes is modified' do
         let(:modified_files) do
           [
             write_file('packs/some_pack/deprecated_references.yml', <<~YML.strip)
@@ -753,6 +753,108 @@ module DangerPackwerk
                   files:
                   - packs/some_pack/some_class1.rb
                   - packs/some_pack/some_class2.rb
+              ==================== DANGER_START
+              Hi! It looks like the pack defining `OtherPackClass` considers this private API.
+              We noticed you ran `bin/packwerk update-deprecations`. Make sure to read through [the docs](https://github.com/Shopify/packwerk/blob/b647594f93c8922c038255a7aaca125d391a1fbf/docs/new_violation_flow_chart.pdf) for other ways to resolve. Could you add some context as a reply here about why we needed to add this violation?
+              ==================== DANGER_END
+            EXPECTED
+          ).and_nothing_else
+        end
+      end
+
+      context 'a deprecated_references.yml file has been modified with files that have been renamed' do
+        let(:renamed_files) do
+          [
+            {
+              after: 'packs/some_pack/some_class_with_new_name.rb',
+              before: 'packs/some_pack/some_class_with_old_name.rb'
+            }
+          ]
+        end
+
+        let(:modified_files) do
+          [
+            write_file('packs/some_pack/deprecated_references.yml', <<~YML.strip)
+              ---
+              packs/some_other_pack:
+                "OtherPackClass":
+                  violations:
+                  - privacy
+                  files:
+                  - packs/some_pack/some_class_with_new_name.rb
+            YML
+          ]
+        end
+
+        let(:some_pack_deprecated_references_before) do
+          write_file('packs/some_pack/deprecated_references.yml', <<~YML.strip)
+            ---
+            packs/some_other_pack:
+              "OtherPackClass":
+                violations:
+                - privacy
+                files:
+                - packs/some_pack/some_class_with_old_name.rb
+          YML
+        end
+
+        it 'does not display a markdown message' do
+          subject
+          expect(dangerfile).to produce_no_danger_messages
+        end
+      end
+
+      context 'a deprecated_references.yml file has been modified with files that have been renamed AND been added' do
+        let(:renamed_files) do
+          [
+            {
+              after: 'packs/some_pack/some_class_with_new_name.rb',
+              before: 'packs/some_pack/some_class_with_old_name.rb'
+            }
+          ]
+        end
+
+        let(:added_files) { ['packs/some_pack/some_entirely_new_class.rb'] }
+
+        let(:modified_files) do
+          [
+            write_file('packs/some_pack/deprecated_references.yml', <<~YML.strip)
+              ---
+              packs/some_other_pack:
+                "OtherPackClass":
+                  violations:
+                  - privacy
+                  files:
+                  - packs/some_pack/some_class_with_new_name.rb
+                  - packs/some_pack/some_entirely_new_class.rb
+            YML
+          ]
+        end
+
+        let(:some_pack_deprecated_references_before) do
+          write_file('packs/some_pack/deprecated_references.yml', <<~YML.strip)
+            ---
+            packs/some_other_pack:
+              "OtherPackClass":
+                violations:
+                - privacy
+                files:
+                - packs/some_pack/some_class_with_old_name.rb
+          YML
+        end
+
+        it 'does not display a markdown message' do
+          subject
+          expect('packs/some_pack/deprecated_references.yml').to contain_inline_markdown(
+            <<~EXPECTED
+              ---
+              packs/some_other_pack:
+                "OtherPackClass":
+                  violations:
+                  - privacy
+                  files:
+                  - packs/some_pack/some_class_with_new_name.rb
+                  - packs/some_pack/some_entirely_new_class.rb
               ==================== DANGER_START
               Hi! It looks like the pack defining `OtherPackClass` considers this private API.
               We noticed you ran `bin/packwerk update-deprecations`. Make sure to read through [the docs](https://github.com/Shopify/packwerk/blob/b647594f93c8922c038255a7aaca125d391a1fbf/docs/new_violation_flow_chart.pdf) for other ways to resolve. Could you add some context as a reply here about why we needed to add this violation?


### PR DESCRIPTION
Renamed files produce false signal because it's not conceptually a "new" violation and creates noise for the user moving code.
