### PR TITLE
Ignore non-default violation types by default

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ GIT
 PATH
   remote: .
   specs:
-    danger-packwerk (0.9.0)
+    danger-packwerk (0.10.0)
       code_ownership
       danger-plugin-api (~> 1.0)
       packwerk

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -136,7 +136,7 @@ GEM
       sawyer (~> 0.9)
     open4 (1.3.4)
     parallel (1.22.1)
-    parse_packwerk (0.15.0)
+    parse_packwerk (0.16.0)
       sorbet-runtime
     parser (3.1.3.0)
       ast (~> 2.4.1)

--- a/lib/danger-packwerk/version.rb
+++ b/lib/danger-packwerk/version.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 module DangerPackwerk
-  VERSION = '0.9.0'
+  VERSION = '0.10.0'
 end

--- a/sorbet/rbi/gems/parse_packwerk@0.16.0.rbi
+++ b/sorbet/rbi/gems/parse_packwerk@0.16.0.rbi
@@ -65,17 +65,20 @@ class ParsePackwerk::Configuration < ::T::Struct
   end
 end
 
-# source://parse_packwerk//lib/parse_packwerk/constants.rb#20
+# source://parse_packwerk//lib/parse_packwerk/constants.rb#22
 ParsePackwerk::DEFAULT_EXCLUDE_GLOBS = T.let(T.unsafe(nil), Array)
 
-# source://parse_packwerk//lib/parse_packwerk/constants.rb#21
+# source://parse_packwerk//lib/parse_packwerk/constants.rb#23
 ParsePackwerk::DEFAULT_PACKAGE_PATHS = T.let(T.unsafe(nil), Array)
 
-# source://parse_packwerk//lib/parse_packwerk/constants.rb#22
+# source://parse_packwerk//lib/parse_packwerk/constants.rb#24
 ParsePackwerk::DEFAULT_PUBLIC_PATH = T.let(T.unsafe(nil), String)
 
-# source://parse_packwerk//lib/parse_packwerk/constants.rb#12
+# source://parse_packwerk//lib/parse_packwerk/constants.rb#14
 ParsePackwerk::DEPENDENCIES = T.let(T.unsafe(nil), String)
+
+# source://parse_packwerk//lib/parse_packwerk/constants.rb#10
+ParsePackwerk::DEPENDENCY_VIOLATION_TYPE = T.let(T.unsafe(nil), String)
 
 # source://parse_packwerk//lib/parse_packwerk/constants.rb#8
 ParsePackwerk::ENFORCE_DEPENDENCIES = T.let(T.unsafe(nil), String)
@@ -83,13 +86,13 @@ ParsePackwerk::ENFORCE_DEPENDENCIES = T.let(T.unsafe(nil), String)
 # source://parse_packwerk//lib/parse_packwerk/constants.rb#9
 ParsePackwerk::ENFORCE_PRIVACY = T.let(T.unsafe(nil), String)
 
-# source://parse_packwerk//lib/parse_packwerk/constants.rb#11
+# source://parse_packwerk//lib/parse_packwerk/constants.rb#13
 ParsePackwerk::METADATA = T.let(T.unsafe(nil), String)
 
 # Since this metadata is unstructured YAML, it could be any type. We leave it to clients of `ParsePackwerk::Package`
 # to add types based on their known usage of metadata.
 #
-# source://parse_packwerk//lib/parse_packwerk/constants.rb#16
+# source://parse_packwerk//lib/parse_packwerk/constants.rb#18
 ParsePackwerk::MetadataYmlType = T.type_alias { T::Hash[T.untyped, T.untyped] }
 
 # source://parse_packwerk//lib/parse_packwerk.rb#14
@@ -108,7 +111,10 @@ ParsePackwerk::PACKAGE_YML_NAME = T.let(T.unsafe(nil), String)
 # source://parse_packwerk//lib/parse_packwerk/constants.rb#6
 ParsePackwerk::PACKWERK_YML_NAME = T.let(T.unsafe(nil), String)
 
-# source://parse_packwerk//lib/parse_packwerk/constants.rb#10
+# source://parse_packwerk//lib/parse_packwerk/constants.rb#11
+ParsePackwerk::PRIVACY_VIOLATION_TYPE = T.let(T.unsafe(nil), String)
+
+# source://parse_packwerk//lib/parse_packwerk/constants.rb#12
 ParsePackwerk::PUBLIC_PATH = T.let(T.unsafe(nil), String)
 
 # source://parse_packwerk//lib/parse_packwerk/package.rb#4


### PR DESCRIPTION
With packwerk 3, arbitrary kinds of packwerk checkers can be created.

The formatters as they exist today only make sense with dependency and privacy violations, so by default, I want to ignore those so the output continues to make sense.

Later, we could come back and allow other violation types to be displayed generically. For now, a user can choose to allow them explicitly, which would require them to implement their own offenses formatter.
