### PR TITLE
Use Packwerk::OffenseCollection instead of T.untyped

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/Shopify/packwerk.git
-  revision: 8476bb3cd5452765ad452d36aa45ae724f1d44f5
+  revision: 7428f23e243a4a172ddb4e28021a732e2c9abc1a
   branch: main
   specs:
     packwerk (2.2.1)
@@ -17,7 +17,7 @@ GIT
 PATH
   remote: .
   specs:
-    danger-packwerk (0.11.0)
+    danger-packwerk (0.11.1)
       code_ownership
       danger-plugin-api (~> 1.0)
       packwerk

--- a/lib/danger-packwerk/packwerk_wrapper.rb
+++ b/lib/danger-packwerk/packwerk_wrapper.rb
@@ -56,9 +56,7 @@ module DangerPackwerk
         ''
       end
 
-      # T.untyped should be Packwerk::OffenseCollection, but is currently private until
-      # https://github.com/Shopify/packwerk/pull/289 merges
-      sig { override.params(offense_collection: T.untyped, for_files: T::Set[String]).returns(String) }
+      sig { override.params(offense_collection: Packwerk::OffenseCollection, for_files: T::Set[String]).returns(String) }
       def show_stale_violations(offense_collection, for_files)
         ''
       end

--- a/lib/danger-packwerk/version.rb
+++ b/lib/danger-packwerk/version.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 module DangerPackwerk
-  VERSION = '0.11.0'
+  VERSION = '0.11.1'
 end

--- a/sorbet/rbi/gems/packwerk@2.2.1-7428f23e243a4a172ddb4e28021a732e2c9abc1a.rbi
+++ b/sorbet/rbi/gems/packwerk@2.2.1-7428f23e243a4a172ddb4e28021a732e2c9abc1a.rbi
@@ -692,7 +692,7 @@ end
 # source://packwerk//lib/packwerk/files_for_processing.rb#8
 Packwerk::FilesForProcessing::RelativeFileSet = T.type_alias { T::Set[::String] }
 
-# source://packwerk//lib/packwerk.rb#51
+# source://packwerk//lib/packwerk.rb#53
 module Packwerk::Formatters
   extend ::ActiveSupport::Autoload
 end
@@ -1288,7 +1288,7 @@ module Packwerk::OutputStyle
   def reset; end
 end
 
-# source://packwerk//lib/packwerk.rb#40
+# source://packwerk//lib/packwerk.rb#42
 module Packwerk::OutputStyles
   extend ::ActiveSupport::Autoload
 end
@@ -2139,11 +2139,11 @@ class Packwerk::Validators::DependencyValidator
   #
   #   ["a -> b -> c -> a", "b -> c -> b"]
   #
-  # source://packwerk//lib/packwerk/validators/dependency_validator.rb#144
+  # source://packwerk//lib/packwerk/validators/dependency_validator.rb#145
   sig { params(cycles: T.untyped).returns(T::Array[::String]) }
   def build_cycle_strings(cycles); end
 
-  # source://packwerk//lib/packwerk/validators/dependency_validator.rb#66
+  # source://packwerk//lib/packwerk/validators/dependency_validator.rb#67
   sig { params(package_set: Packwerk::PackageSet).returns(::Packwerk::Validator::Result) }
   def check_acyclic_graph(package_set); end
 
@@ -2151,11 +2151,11 @@ class Packwerk::Validators::DependencyValidator
   sig { params(configuration: ::Packwerk::Configuration).returns(::Packwerk::Validator::Result) }
   def check_package_manifest_syntax(configuration); end
 
-  # source://packwerk//lib/packwerk/validators/dependency_validator.rb#92
+  # source://packwerk//lib/packwerk/validators/dependency_validator.rb#93
   sig { params(configuration: ::Packwerk::Configuration).returns(::Packwerk::Validator::Result) }
   def check_valid_package_dependencies(configuration); end
 
-  # source://packwerk//lib/packwerk/validators/dependency_validator.rb#128
+  # source://packwerk//lib/packwerk/validators/dependency_validator.rb#129
   sig { params(configuration: ::Packwerk::Configuration, path: T.untyped).returns(T::Boolean) }
   def invalid_package_path?(configuration, path); end
 end


### PR DESCRIPTION
Now that `OffenseCollection` is public API again, we can reference it directly without an error.
