### PR TITLE
Namespace offenses aggregator

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ GIT
 PATH
   remote: .
   specs:
-    danger-packwerk (0.11.1)
+    danger-packwerk (0.11.2)
       code_ownership
       danger-plugin-api (~> 1.0)
       packwerk

--- a/lib/danger-packwerk/packwerk_wrapper.rb
+++ b/lib/danger-packwerk/packwerk_wrapper.rb
@@ -68,7 +68,7 @@ module DangerPackwerk
 
       sig { override.returns(::String) }
       def identifier
-        'offenses_aggregator'
+        'danger_packwerk_offenses_aggregator'
       end
     end
   end

--- a/lib/danger-packwerk/version.rb
+++ b/lib/danger-packwerk/version.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 module DangerPackwerk
-  VERSION = '0.11.1'
+  VERSION = '0.11.2'
 end


### PR DESCRIPTION
This addresses an issue where an offenses aggregator in `use_packs` with the same identifier is causing an error in packwerk, which only allows one aggregator with the same name.
