### PR TITLE
refactor DangerPackageTodoYmlChanges to expose class helper method

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,7 +18,7 @@ GIT
 PATH
   remote: .
   specs:
-    danger-packwerk (0.14.3)
+    danger-packwerk (0.14.4)
       code_ownership
       danger-plugin-api (~> 1.0)
       packs

--- a/lib/danger-packwerk/danger_package_todo_yml_changes.rb
+++ b/lib/danger-packwerk/danger_package_todo_yml_changes.rb
@@ -74,11 +74,11 @@ module DangerPackwerk
     sig do
       params(
         violation_types: T::Array[String],
-        git: T.nilable(Danger::DangerfileGitPlugin),
+        git: Danger::DangerfileGitPlugin,
         root_path: T.nilable(String)
       ).returns(ViolationDiff)
     end
-    def self.get_violation_diff(violation_types, git: nil, root_path: nil)
+    def self.get_violation_diff(violation_types, git:, root_path: nil)
       git_filesystem = Private::GitFilesystem.new(git: git, root: root_path || '')
 
       added_violations, removed_violations = Private::TodoYmlChanges.get_reference_offenses(

--- a/lib/danger-packwerk/danger_package_todo_yml_changes.rb
+++ b/lib/danger-packwerk/danger_package_todo_yml_changes.rb
@@ -47,7 +47,7 @@ module DangerPackwerk
       git_filesystem = Private::GitFilesystem.new(git: git, root: root_path || '')
       changed_package_todo_ymls = (git_filesystem.modified_files + git_filesystem.added_files + git_filesystem.deleted_files).grep(PACKAGE_TODO_PATTERN)
 
-      violation_diff = get_violation_diff(violation_types, root_path: root_path)
+      violation_diff = DangerPackageTodoYmlChanges.get_violation_diff(violation_types, git: git, root_path: root_path)
 
       before_comment.call(
         violation_diff,
@@ -74,10 +74,11 @@ module DangerPackwerk
     sig do
       params(
         violation_types: T::Array[String],
+        git: T.nilable(Danger::DangerfileGitPlugin),
         root_path: T.nilable(String)
       ).returns(ViolationDiff)
     end
-    def get_violation_diff(violation_types, root_path: nil)
+    def self.get_violation_diff(violation_types, git: nil, root_path: nil)
       git_filesystem = Private::GitFilesystem.new(git: git, root: root_path || '')
 
       added_violations, removed_violations = Private::TodoYmlChanges.get_reference_offenses(

--- a/lib/danger-packwerk/version.rb
+++ b/lib/danger-packwerk/version.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 module DangerPackwerk
-  VERSION = '0.14.3'
+  VERSION = '0.14.4'
 end


### PR DESCRIPTION
Authored by @anokhigusto.

We wanted to expose this helper as a class method to make it easier to use outside of this plugin.