### PR TITLE
Generate links in formatter using head ref

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ plugins:
   - rubocop-performance
 
 AllCops:
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 3.1
   NewCops: enable
   Exclude:
     - bin/**/*

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,7 +18,7 @@ GIT
 PATH
   remote: .
   specs:
-    danger-packwerk (0.14.4)
+    danger-packwerk (0.15.0)
       code_ownership
       danger-plugin-api (~> 1.0)
       packs

--- a/README.md
+++ b/README.md
@@ -43,8 +43,15 @@ class MyFormatter
   extend T::Sig
   include DangerPackwerk::Check::OffensesFormatter
   # Packwerk::ReferenceOffense: https://github.com/Shopify/packwerk/blob/main/lib/packwerk/reference_offense.rb
-  sig { override.params(offenses: T::Array[Packwerk::ReferenceOffense], repo_link: String, org_name: String).returns(String) }
-  def format_offenses(offenses, repo_link, org_name)
+  sig do
+    override.params(
+      offenses: T::Array[Packwerk::ReferenceOffense],
+      repo_link: String,
+      org_name: String
+      repo_url_builder: T.nilable(T.proc.params(constant_path: String).returns(String))
+    ).returns(String)
+  end
+  def format_offenses(offenses, repo_link, org_name, repo_builder_url: nil)
     # your logic here
   end
 end
@@ -98,8 +105,15 @@ class MyFormatter
   extend T::Sig
   include DangerPackwerk::Update::OffensesFormatter
   # DangerPackwerk::BasicReferenceOffense
-  sig { override.params(offenses: T::Array[DangerPackwerk::BasicReferenceOffense], repo_link: String, org_name: String).returns(String) }
-  def format_offenses(offenses, repo_link, org_name)
+  sig do
+    override.params(
+      offenses: T::Array[Packwerk::ReferenceOffense],
+      repo_link: String,
+      org_name: String
+      repo_url_builder: T.nilable(T.proc.params(constant_path: String).returns(String))
+    ).returns(String)
+  end
+  def format_offenses(offenses, repo_link, org_name, repo_builder_url: nil)
     # your logic here
   end
 end

--- a/danger-packwerk.gemspec
+++ b/danger-packwerk.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir['README.md', 'lib/**/*']
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 2.6'
+  spec.required_ruby_version = '>= 3.1'
 
   spec.add_dependency 'code_ownership'
   spec.add_dependency 'danger-plugin-api', '~> 1.0'

--- a/lib/danger-packwerk.rb
+++ b/lib/danger-packwerk.rb
@@ -5,7 +5,7 @@
 require 'sorbet-runtime'
 
 module DangerPackwerk
-  PACKAGE_TODO_PATTERN = T.let(/.*?package_todo\.yml\z/.freeze, Regexp)
+  PACKAGE_TODO_PATTERN = T.let(/.*?package_todo\.yml\z/, Regexp)
   DEPENDENCY_VIOLATION_TYPE = 'dependency'
   PRIVACY_VIOLATION_TYPE = 'privacy'
 

--- a/lib/danger-packwerk/check/default_formatter.rb
+++ b/lib/danger-packwerk/check/default_formatter.rb
@@ -46,11 +46,12 @@ module DangerPackwerk
         team_to_work_with = constant_source_package_ownership_info.owning_team ? constant_source_package_ownership_info.markdown_link_to_github_members_no_tag : 'the pack owner'
         privacy_violation_message = "- Does API in #{constant_source_package.name}/public support this use case?\n  - If not, can we work with #{team_to_work_with} to create and use a public API?\n  - If `#{constant_name}` should already be public, try `bin/packs make_public #{constant_location}`."
 
-        if repo_url_builder
-          constant_location_url = repo_url_builder.call(constant_location)
-        else
-          constant_location_url = "#{repo_link}/blob/main/#{constant_location}"
-        end
+        constant_location_url =
+          if repo_url_builder
+            repo_url_builder.call(constant_location)
+          else
+            "#{repo_link}/blob/main/#{constant_location}"
+          end
 
         if violation_types.include?(::DangerPackwerk::DEPENDENCY_VIOLATION_TYPE) && violation_types.include?(::DangerPackwerk::PRIVACY_VIOLATION_TYPE)
           <<~MESSAGE

--- a/lib/danger-packwerk/check/default_formatter.rb
+++ b/lib/danger-packwerk/check/default_formatter.rb
@@ -21,10 +21,11 @@ module DangerPackwerk
         override.params(
           offenses: T::Array[Packwerk::ReferenceOffense],
           repo_link: String,
-          org_name: String
+          org_name: String,
+          repo_url_builder: T.nilable(T.proc.params(constant_path: String).returns(String))
         ).returns(String)
       end
-      def format_offenses(offenses, repo_link, org_name)
+      def format_offenses(offenses, repo_link, org_name, repo_url_builder: nil)
         reference_offense = T.must(offenses.first)
         violation_types = offenses.map(&:violation_type)
         referencing_file = reference_offense.reference.relative_path

--- a/lib/danger-packwerk/check/default_formatter.rb
+++ b/lib/danger-packwerk/check/default_formatter.rb
@@ -46,11 +46,17 @@ module DangerPackwerk
         team_to_work_with = constant_source_package_ownership_info.owning_team ? constant_source_package_ownership_info.markdown_link_to_github_members_no_tag : 'the pack owner'
         privacy_violation_message = "- Does API in #{constant_source_package.name}/public support this use case?\n  - If not, can we work with #{team_to_work_with} to create and use a public API?\n  - If `#{constant_name}` should already be public, try `bin/packs make_public #{constant_location}`."
 
+        if repo_url_builder
+          constant_location_url = repo_url_builder.call(constant_location)
+        else
+          constant_location_url = "#{repo_link}/blob/main/#{constant_location}"
+        end
+
         if violation_types.include?(::DangerPackwerk::DEPENDENCY_VIOLATION_TYPE) && violation_types.include?(::DangerPackwerk::PRIVACY_VIOLATION_TYPE)
           <<~MESSAGE
             **Packwerk Violation**
             - Type: Privacy :lock: + Dependency :knot:
-            - Constant: [<ins>`#{constant_name}`</ins>](#{repo_link}/blob/main/#{constant_location})
+            - Constant: [<ins>`#{constant_name}`</ins>](#{constant_location_url})
             - Owning pack: #{constant_source_package_name}
               #{constant_source_package_ownership_info.ownership_copy}
 
@@ -70,7 +76,7 @@ module DangerPackwerk
           <<~MESSAGE
             **Packwerk Violation**
             - Type: Dependency :knot:
-            - Constant: [<ins>`#{constant_name}`</ins>](#{repo_link}/blob/main/#{constant_location})
+            - Constant: [<ins>`#{constant_name}`</ins>](#{constant_location_url})
             - Owning pack: #{constant_source_package_name}
               #{constant_source_package_ownership_info.ownership_copy}
 
@@ -89,7 +95,7 @@ module DangerPackwerk
           <<~MESSAGE
             **Packwerk Violation**
             - Type: Privacy :lock:
-            - Constant: [<ins>`#{constant_name}`</ins>](#{repo_link}/blob/main/#{constant_location})
+            - Constant: [<ins>`#{constant_name}`</ins>](#{constant_location_url})
             - Owning pack: #{constant_source_package_name}
               #{constant_source_package_ownership_info.ownership_copy}
 

--- a/lib/danger-packwerk/check/offenses_formatter.rb
+++ b/lib/danger-packwerk/check/offenses_formatter.rb
@@ -14,10 +14,11 @@ module DangerPackwerk
         abstract.params(
           offenses: T::Array[Packwerk::ReferenceOffense],
           repo_link: String,
-          org_name: String
+          org_name: String,
+          repo_url_builder: T.nilable(T.proc.params(constant_path: String).returns(String))
         ).returns(String)
       end
-      def format_offenses(offenses, repo_link, org_name); end
+      def format_offenses(offenses, repo_link, org_name, repo_url_builder: nil); end
     end
   end
 end

--- a/lib/danger-packwerk/danger_package_todo_yml_changes.rb
+++ b/lib/danger-packwerk/danger_package_todo_yml_changes.rb
@@ -42,7 +42,7 @@ module DangerPackwerk
     )
       offenses_formatter ||= Update::DefaultFormatter.new
       repo_link = github.pr_json[:base][:repo][:html_url]
-      repo_url_builder = ->(constant_path) { "#{repo_link}/blob/main/#{constant_path}" }
+      repo_url_builder = ->(constant_path) { "#{repo_link}/blob/#{github.pr_json[:head][:ref]}/#{constant_path}" }
       org_name = github.pr_json[:base][:repo][:owner][:login]
 
       git_filesystem = Private::GitFilesystem.new(git: git, root: root_path || '')

--- a/lib/danger-packwerk/danger_package_todo_yml_changes.rb
+++ b/lib/danger-packwerk/danger_package_todo_yml_changes.rb
@@ -42,6 +42,7 @@ module DangerPackwerk
     )
       offenses_formatter ||= Update::DefaultFormatter.new
       repo_link = github.pr_json[:base][:repo][:html_url]
+      repo_url_builder = ->(constant_path) { "#{github.pr_json[:base][:repo][:html_url]}/blob/main/#{constant_path}" }
       org_name = github.pr_json[:base][:repo][:owner][:login]
 
       git_filesystem = Private::GitFilesystem.new(git: git, root: root_path || '')
@@ -62,7 +63,7 @@ module DangerPackwerk
         location = T.must(violations.first).file_location
 
         markdown(
-          offenses_formatter.format_offenses(violations, repo_link, org_name),
+          offenses_formatter.format_offenses(violations, repo_link, org_name, repo_url_builder: repo_url_builder),
           line: location.line_number,
           file: git_filesystem.convert_to_filesystem(location.file)
         )

--- a/lib/danger-packwerk/danger_package_todo_yml_changes.rb
+++ b/lib/danger-packwerk/danger_package_todo_yml_changes.rb
@@ -42,7 +42,7 @@ module DangerPackwerk
     )
       offenses_formatter ||= Update::DefaultFormatter.new
       repo_link = github.pr_json[:base][:repo][:html_url]
-      repo_url_builder = ->(constant_path) { "#{github.pr_json[:base][:repo][:html_url]}/blob/main/#{constant_path}" }
+      repo_url_builder = ->(constant_path) { "#{repo_link}/blob/main/#{constant_path}" }
       org_name = github.pr_json[:base][:repo][:owner][:login]
 
       git_filesystem = Private::GitFilesystem.new(git: git, root: root_path || '')

--- a/lib/danger-packwerk/danger_packwerk.rb
+++ b/lib/danger-packwerk/danger_packwerk.rb
@@ -64,6 +64,7 @@ module DangerPackwerk
     )
       offenses_formatter ||= Check::DefaultFormatter.new
       repo_link = github.pr_json[:base][:repo][:html_url]
+      repo_url_builder = ->(constant_path) { "#{repo_link}/blob/main/#{constant_path}" }
       org_name = github.pr_json[:base][:repo][:owner][:login]
 
       # This is important because by default, Danger will leave a concantenated list of all its messages if it can't find a commentable place in the
@@ -140,7 +141,7 @@ module DangerPackwerk
         line_number = reference_offense.location&.line
         referencing_file = reference_offense.reference.relative_path
 
-        message = offenses_formatter.format_offenses(unique_packwerk_reference_offenses, repo_link, org_name)
+        message = offenses_formatter.format_offenses(unique_packwerk_reference_offenses, repo_link, org_name, repo_url_builder: repo_url_builder)
         markdown(message, file: git_filesystem.convert_to_filesystem(referencing_file), line: line_number)
       end
 

--- a/lib/danger-packwerk/danger_packwerk.rb
+++ b/lib/danger-packwerk/danger_packwerk.rb
@@ -64,7 +64,7 @@ module DangerPackwerk
     )
       offenses_formatter ||= Check::DefaultFormatter.new
       repo_link = github.pr_json[:base][:repo][:html_url]
-      repo_url_builder = ->(constant_path) { "#{repo_link}/blob/main/#{constant_path}" }
+      repo_url_builder = ->(constant_path) { "#{repo_link}/blob/#{github.pr_json[:head][:ref]}/#{constant_path}" }
       org_name = github.pr_json[:base][:repo][:owner][:login]
 
       # This is important because by default, Danger will leave a concantenated list of all its messages if it can't find a commentable place in the

--- a/lib/danger-packwerk/update/default_formatter.rb
+++ b/lib/danger-packwerk/update/default_formatter.rb
@@ -15,8 +15,15 @@ module DangerPackwerk
         @custom_help_message = custom_help_message
       end
 
-      sig { override.params(offenses: T::Array[BasicReferenceOffense], repo_link: String, org_name: String).returns(String) }
-      def format_offenses(offenses, repo_link, org_name)
+      sig do
+        override.params(
+          offenses: T::Array[BasicReferenceOffense],
+          repo_link: String,
+          org_name: String,
+          repo_url_builder: T.nilable(T.proc.params(constant_path: String).returns(String))
+        ).returns(String)
+      end
+      def format_offenses(offenses, repo_link, org_name, repo_url_builder: nil)
         violation = T.must(offenses.first)
         referencing_file_pack = ParsePackwerk.package_from_path(violation.file)
         # We remove leading double colons as they feel like an implementation detail of packwerk.

--- a/lib/danger-packwerk/update/offenses_formatter.rb
+++ b/lib/danger-packwerk/update/offenses_formatter.rb
@@ -14,10 +14,11 @@ module DangerPackwerk
         abstract.params(
           offenses: T::Array[BasicReferenceOffense],
           repo_link: String,
-          org_name: String
+          org_name: String,
+          repo_url_builder: T.nilable(T.proc.params(constant_path: String).returns(String))
         ).returns(String)
       end
-      def format_offenses(offenses, repo_link, org_name); end
+      def format_offenses(offenses, repo_link, org_name, repo_url_builder: nil); end
     end
   end
 end

--- a/lib/danger-packwerk/version.rb
+++ b/lib/danger-packwerk/version.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 module DangerPackwerk
-  VERSION = '0.14.4'
+  VERSION = '0.15.0'
 end

--- a/spec/danger_packwerk/danger_package_todo_yml_changes_spec.rb
+++ b/spec/danger_packwerk/danger_package_todo_yml_changes_spec.rb
@@ -145,7 +145,7 @@ module DangerPackwerk
             Class.new do
               include Update::OffensesFormatter
 
-              def format_offenses(added_violations, repo_link, org_name)
+              def format_offenses(added_violations, repo_link, org_name, repo_url_builder: nil)
                 <<~MESSAGE
                   There are #{added_violations.count} new violations,
                   with class_names #{added_violations.map(&:class_name).uniq.sort},
@@ -1159,7 +1159,7 @@ module DangerPackwerk
             Class.new do
               include Update::OffensesFormatter
 
-              def format_offenses(added_violations, repo_link, org_name)
+              def format_offenses(added_violations, repo_link, org_name, repo_url_builder: nil)
                 <<~MESSAGE
                   There are #{added_violations.count} new violations,
                   with class_names #{added_violations.map(&:class_name).uniq.sort},

--- a/spec/danger_packwerk/danger_packwerk_spec.rb
+++ b/spec/danger_packwerk/danger_packwerk_spec.rb
@@ -859,7 +859,7 @@ module DangerPackwerk
             expected = <<~EXPECTED
               **Packwerk Violation**
               - Type: Privacy :lock:
-              - Constant: [<ins>`PrivateConstant`</ins>](https://github.com/MyOrg/my_repo/blob/main/packs/gusto_slack/app/services/private_constant.rb)
+              - Constant: [<ins>`PrivateConstant`</ins>](https://github.com/MyOrg/my_repo/blob/my_branch/packs/gusto_slack/app/services/private_constant.rb)
               - Owning pack: packs/gusto_slack
                 - Owned by [<ins>@MyOrg/product-infrastructure</ins>](https://github.com/orgs/MyOrg/teams/product-infrastructure/members) (Slack: [<ins>#prod-infra</ins>](https://slack.com/app_redirect?channel=prod-infra))
 
@@ -900,7 +900,7 @@ module DangerPackwerk
               expected = <<~EXPECTED
                 **Packwerk Violation**
                 - Type: Privacy :lock:
-                - Constant: [<ins>`PrivateConstant`</ins>](https://github.com/MyOrg/my_repo/blob/main/packs/gusto_slack/app/services/private_constant.rb)
+                - Constant: [<ins>`PrivateConstant`</ins>](https://github.com/MyOrg/my_repo/blob/my_branch/packs/gusto_slack/app/services/private_constant.rb)
                 - Owning pack: packs/gusto_slack
                   - This pack is unowned.
 
@@ -943,7 +943,7 @@ module DangerPackwerk
             expected = <<~EXPECTED
               **Packwerk Violation**
               - Type: Dependency :knot:
-              - Constant: [<ins>`PrivateConstant`</ins>](https://github.com/MyOrg/my_repo/blob/main/packs/gusto_slack/app/services/private_constant.rb)
+              - Constant: [<ins>`PrivateConstant`</ins>](https://github.com/MyOrg/my_repo/blob/my_branch/packs/gusto_slack/app/services/private_constant.rb)
               - Owning pack: packs/gusto_slack
                 - Owned by [<ins>@MyOrg/product-infrastructure</ins>](https://github.com/orgs/MyOrg/teams/product-infrastructure/members) (Slack: [<ins>#prod-infra</ins>](https://slack.com/app_redirect?channel=prod-infra))
 
@@ -984,7 +984,7 @@ module DangerPackwerk
             expected = <<~EXPECTED
               **Packwerk Violation**
               - Type: Privacy :lock: + Dependency :knot:
-              - Constant: [<ins>`PrivateConstant`</ins>](https://github.com/MyOrg/my_repo/blob/main/packs/gusto_slack/app/services/private_constant.rb)
+              - Constant: [<ins>`PrivateConstant`</ins>](https://github.com/MyOrg/my_repo/blob/my_branch/packs/gusto_slack/app/services/private_constant.rb)
               - Owning pack: packs/gusto_slack
                 - Owned by [<ins>@MyOrg/product-infrastructure</ins>](https://github.com/orgs/MyOrg/teams/product-infrastructure/members) (Slack: [<ins>#prod-infra</ins>](https://slack.com/app_redirect?channel=prod-infra))
 
@@ -1057,7 +1057,7 @@ module DangerPackwerk
               expected = <<~EXPECTED
                 **Packwerk Violation**
                 - Type: Privacy :lock:
-                - Constant: [<ins>`PrivateConstant`</ins>](https://github.com/MyOrg/my_repo/blob/main/packs/gusto_slack/app/services/private_constant.rb)
+                - Constant: [<ins>`PrivateConstant`</ins>](https://github.com/MyOrg/my_repo/blob/my_branch/packs/gusto_slack/app/services/private_constant.rb)
                 - Owning pack: packs/gusto_slack
                   - Owned by [<ins>@MyOrg/product-infrastructure</ins>](https://github.com/orgs/MyOrg/teams/product-infrastructure/members) (Slack: [<ins>#prod-infra</ins>](https://slack.com/app_redirect?channel=prod-infra))
 

--- a/spec/danger_packwerk/danger_packwerk_spec.rb
+++ b/spec/danger_packwerk/danger_packwerk_spec.rb
@@ -26,7 +26,7 @@ module DangerPackwerk
       context 'using inputted formatter' do
         let(:packwerk) { dangerfile.packwerk }
         let(:constant) do
-          sorbet_double(Packwerk::ConstantContext, location: Packwerk::Node::Location.new(12, 5), package: double(name: 'packs/some_pack'), name: '::PrivateConstant')
+          sorbet_double(Packwerk::ConstantContext, location: 'some/location.rb', package: double(name: 'packs/some_pack'), name: '::PrivateConstant')
         end
         let(:generic_dependency_violation) do
           sorbet_double(
@@ -58,8 +58,11 @@ module DangerPackwerk
           Class.new do
             include Check::OffensesFormatter
 
-            def format_offenses(offenses, repo_link, org_name, repo_url_builder: nil)
-              offenses.map(&:message).join("\n\n")
+            def format_offenses(offenses, repo_link, org_name, repo_url_builder:)
+              constant_location = offenses.first.reference.constant.location
+              constant_name = offenses.first.reference.constant.name
+              url = repo_url_builder&.call(constant_location.to_s)
+              offenses.map { |offense| "#{offense.message} [#{constant_name}](#{url})" }.join("\n\n")
             end
           end
         end
@@ -117,7 +120,7 @@ module DangerPackwerk
             actual_markdowns = dangerfile.status_report[:markdowns]
             expect(actual_markdowns.count).to eq 1
             actual_markdown = actual_markdowns.first
-            expect(actual_markdown.message).to eq 'Vanilla message about privacy violations'
+            expect(actual_markdown.message).to eq 'Vanilla message about privacy violations [::PrivateConstant](https://github.com/MyOrg/my_repo/blob/my_branch/some/location.rb)'
             expect(actual_markdown.line).to eq 12
             expect(actual_markdown.file).to eq 'packs/referencing_pack/some_file.rb'
             expect(actual_markdown.type).to eq :markdown
@@ -136,7 +139,7 @@ module DangerPackwerk
               actual_markdowns = dangerfile.status_report[:markdowns]
               expect(actual_markdowns.count).to eq 1
               actual_markdown = actual_markdowns.first
-              expect(actual_markdown.message).to eq 'Vanilla message about privacy violations'
+              expect(actual_markdown.message).to eq 'Vanilla message about privacy violations [::PrivateConstant](https://github.com/MyOrg/my_repo/blob/my_branch/some/location.rb)'
               expect(actual_markdown.line).to eq 12
               expect(actual_markdown.file).to eq 'packs/referencing_pack/some_file.rb'
               expect(actual_markdown.type).to eq :markdown
@@ -154,7 +157,7 @@ module DangerPackwerk
             actual_markdowns = dangerfile.status_report[:markdowns]
             expect(actual_markdowns.count).to eq 1
             actual_markdown = actual_markdowns.first
-            expect(actual_markdown.message).to eq 'Vanilla message about dependency violations'
+            expect(actual_markdown.message).to eq 'Vanilla message about dependency violations [::PrivateConstant](https://github.com/MyOrg/my_repo/blob/my_branch/some/location.rb)'
             expect(actual_markdown.line).to eq 12
             expect(actual_markdown.file).to eq 'packs/referencing_pack/some_file.rb'
             expect(actual_markdown.type).to eq :markdown
@@ -171,7 +174,7 @@ module DangerPackwerk
             actual_markdowns = dangerfile.status_report[:markdowns]
             expect(actual_markdowns.count).to eq 1
             actual_markdown = actual_markdowns.first
-            expect(actual_markdown.message).to eq "Vanilla message about dependency violations\n\nVanilla message about privacy violations"
+            expect(actual_markdown.message).to eq "Vanilla message about dependency violations [::PrivateConstant](https://github.com/MyOrg/my_repo/blob/my_branch/some/location.rb)\n\nVanilla message about privacy violations [::PrivateConstant](https://github.com/MyOrg/my_repo/blob/my_branch/some/location.rb)"
             expect(actual_markdown.line).to eq 12
             expect(actual_markdown.file).to eq 'packs/referencing_pack/some_file.rb'
             expect(actual_markdown.type).to eq :markdown
@@ -193,7 +196,7 @@ module DangerPackwerk
             actual_markdowns = dangerfile.status_report[:markdowns]
             expect(actual_markdowns.count).to eq 1
             actual_markdown = actual_markdowns.first
-            expect(actual_markdown.message).to eq "Vanilla message about dependency violations\n\nVanilla message about privacy violations"
+            expect(actual_markdown.message).to eq "Vanilla message about dependency violations [::PrivateConstant](https://github.com/MyOrg/my_repo/blob/my_branch/some/location.rb)\n\nVanilla message about privacy violations [::PrivateConstant](https://github.com/MyOrg/my_repo/blob/my_branch/some/location.rb)"
             expect(actual_markdown.line).to eq 12
             expect(actual_markdown.file).to eq "#{root_path}packs/referencing_pack/some_file.rb"
             expect(actual_markdown.type).to eq :markdown
@@ -217,7 +220,7 @@ module DangerPackwerk
               actual_markdowns = dangerfile.status_report[:markdowns]
               expect(actual_markdowns.count).to eq 1
               actual_markdown = actual_markdowns.first
-              expect(actual_markdown.message).to eq 'Vanilla message about privacy violations'
+              expect(actual_markdown.message).to eq 'Vanilla message about privacy violations [::PrivateConstant](https://github.com/MyOrg/my_repo/blob/my_branch/some/location.rb)'
               expect(actual_markdown.line).to eq 12
               expect(actual_markdown.file).to eq "#{root_path}packs/referencing_pack/some_file.rb"
               expect(actual_markdown.type).to eq :markdown
@@ -262,7 +265,7 @@ module DangerPackwerk
                 actual_markdowns = dangerfile.status_report[:markdowns]
                 expect(actual_markdowns.count).to eq 1
                 actual_markdown = actual_markdowns.first
-                expect(actual_markdown.message).to eq "Vanilla message about privacy violations\n\nVanilla message about dependency violations"
+                expect(actual_markdown.message).to eq "Vanilla message about privacy violations [::PrivateConstant](https://github.com/MyOrg/my_repo/blob/my_branch/some/location.rb)\n\nVanilla message about dependency violations [::PrivateConstant](https://github.com/MyOrg/my_repo/blob/my_branch/some/location.rb)"
                 expect(actual_markdown.line).to eq 12
                 expect(actual_markdown.file).to eq 'packs/referencing_pack/some_file.rb'
                 expect(actual_markdown.type).to eq :markdown
@@ -306,13 +309,13 @@ module DangerPackwerk
                 expect(actual_markdowns.count).to eq 2
 
                 first_actual_markdown = actual_markdowns.first
-                expect(first_actual_markdown.message).to eq 'Vanilla message about privacy violations'
+                expect(first_actual_markdown.message).to eq 'Vanilla message about privacy violations [::PrivateConstant](https://github.com/MyOrg/my_repo/blob/my_branch/some/location.rb)'
                 expect(first_actual_markdown.line).to eq 12
                 expect(first_actual_markdown.file).to eq 'packs/referencing_pack/some_file.rb'
                 expect(first_actual_markdown.type).to eq :markdown
 
                 second_actual_markdown = actual_markdowns.last
-                expect(second_actual_markdown.message).to eq 'Vanilla message about privacy violations'
+                expect(second_actual_markdown.message).to eq 'Vanilla message about privacy violations [::PrivateConstant](https://github.com/MyOrg/my_repo/blob/my_branch/some/location.rb)'
                 expect(second_actual_markdown.line).to eq 22
                 expect(second_actual_markdown.file).to eq 'packs/referencing_pack/some_file.rb'
                 expect(second_actual_markdown.type).to eq :markdown
@@ -356,13 +359,13 @@ module DangerPackwerk
                 expect(actual_markdowns.count).to eq 2
 
                 first_actual_markdown = actual_markdowns.first
-                expect(first_actual_markdown.message).to eq 'Vanilla message about privacy violations'
+                expect(first_actual_markdown.message).to eq 'Vanilla message about privacy violations [::PrivateConstant](https://github.com/MyOrg/my_repo/blob/my_branch/some/location.rb)'
                 expect(first_actual_markdown.line).to eq 12
                 expect(first_actual_markdown.file).to eq 'packs/referencing_pack/some_file.rb'
                 expect(first_actual_markdown.type).to eq :markdown
 
                 second_actual_markdown = actual_markdowns.last
-                expect(second_actual_markdown.message).to eq 'Vanilla message about privacy violations'
+                expect(second_actual_markdown.message).to eq 'Vanilla message about privacy violations [::PrivateConstant](https://github.com/MyOrg/my_repo/blob/my_branch/some/location.rb)'
                 expect(second_actual_markdown.line).to eq 12
                 expect(second_actual_markdown.file).to eq 'packs/referencing_pack/some_other_file.rb'
                 expect(second_actual_markdown.type).to eq :markdown
@@ -406,13 +409,13 @@ module DangerPackwerk
                 expect(actual_markdowns.count).to eq 2
 
                 first_actual_markdown = actual_markdowns.first
-                expect(first_actual_markdown.message).to eq 'Vanilla message about privacy violations'
+                expect(first_actual_markdown.message).to eq 'Vanilla message about privacy violations [::PrivateConstant](https://github.com/MyOrg/my_repo/blob/my_branch/some/location.rb)'
                 expect(first_actual_markdown.line).to eq 12
                 expect(first_actual_markdown.file).to eq 'packs/referencing_pack/some_file.rb'
                 expect(first_actual_markdown.type).to eq :markdown
 
                 second_actual_markdown = actual_markdowns.last
-                expect(second_actual_markdown.message).to eq 'Vanilla message about privacy violations'
+                expect(second_actual_markdown.message).to eq 'Vanilla message about privacy violations [::PrivateConstant](https://github.com/MyOrg/my_repo/blob/my_branch/some/location.rb)'
                 expect(second_actual_markdown.line).to eq 12
                 expect(second_actual_markdown.file).to eq 'packs/another_referencing_pack/some_file.rb'
                 expect(second_actual_markdown.type).to eq :markdown
@@ -463,7 +466,7 @@ module DangerPackwerk
                 actual_markdowns = dangerfile.status_report[:markdowns]
                 expect(actual_markdowns.count).to eq 1
                 actual_markdown = actual_markdowns.first
-                expect(actual_markdown.message).to eq "Vanilla message about privacy violations\n\nVanilla message about dependency violations"
+                expect(actual_markdown.message).to eq "Vanilla message about privacy violations [::PrivateConstant](https://github.com/MyOrg/my_repo/blob/my_branch/some/location.rb)\n\nVanilla message about dependency violations [::PrivateConstant](https://github.com/MyOrg/my_repo/blob/my_branch/some/location.rb)"
                 expect(actual_markdown.line).to eq 12
                 expect(actual_markdown.file).to eq 'packs/referencing_pack/some_file.rb'
                 expect(actual_markdown.type).to eq :markdown
@@ -505,7 +508,7 @@ module DangerPackwerk
                 actual_markdowns = dangerfile.status_report[:markdowns]
                 expect(actual_markdowns.count).to eq 1
                 actual_markdown = actual_markdowns.first
-                expect(actual_markdown.message).to eq "Vanilla message about privacy violations\n\nVanilla message about privacy violations"
+                expect(actual_markdown.message).to eq "Vanilla message about privacy violations [::PrivateConstant](https://github.com/MyOrg/my_repo/blob/my_branch/some/location.rb)\n\nVanilla message about privacy violations [::PrivateConstant](https://github.com/MyOrg/my_repo/blob/my_branch/some/location.rb)"
                 expect(actual_markdown.line).to eq 12
                 expect(actual_markdown.file).to eq 'packs/referencing_pack/some_file.rb'
                 expect(actual_markdown.type).to eq :markdown
@@ -547,7 +550,7 @@ module DangerPackwerk
                 actual_markdowns = dangerfile.status_report[:markdowns]
                 expect(actual_markdowns.count).to eq 1
                 actual_markdown = actual_markdowns.first
-                expect(actual_markdown.message).to eq "Vanilla message about privacy violations\n\nVanilla message about privacy violations"
+                expect(actual_markdown.message).to eq "Vanilla message about privacy violations [::PrivateConstant](https://github.com/MyOrg/my_repo/blob/my_branch/some/location.rb)\n\nVanilla message about privacy violations [::PrivateConstant](https://github.com/MyOrg/my_repo/blob/my_branch/some/location.rb)"
                 expect(actual_markdown.line).to eq 12
                 expect(actual_markdown.file).to eq 'packs/referencing_pack/some_file.rb'
                 expect(actual_markdown.type).to eq :markdown
@@ -602,13 +605,13 @@ module DangerPackwerk
                 expect(actual_markdowns.count).to eq 2
 
                 first_actual_markdown = actual_markdowns.first
-                expect(first_actual_markdown.message).to eq 'Vanilla message about privacy violations'
+                expect(first_actual_markdown.message).to eq 'Vanilla message about privacy violations [::PrivateConstant](https://github.com/MyOrg/my_repo/blob/my_branch/some/location.rb)'
                 expect(first_actual_markdown.line).to eq 12
                 expect(first_actual_markdown.file).to eq 'packs/referencing_pack/some_file.rb'
                 expect(first_actual_markdown.type).to eq :markdown
 
                 second_actual_markdown = actual_markdowns.last
-                expect(second_actual_markdown.message).to eq 'Vanilla message about privacy violations'
+                expect(second_actual_markdown.message).to eq 'Vanilla message about privacy violations [::PrivateConstant](https://github.com/MyOrg/my_repo/blob/my_branch/some/location.rb)'
                 expect(second_actual_markdown.line).to eq 12
                 expect(second_actual_markdown.file).to eq 'packs/another_referencing_pack/some_file.rb'
                 expect(second_actual_markdown.type).to eq :markdown
@@ -756,7 +759,7 @@ module DangerPackwerk
               actual_markdowns = dangerfile.status_report[:markdowns]
               expect(actual_markdowns.count).to eq 1
               actual_markdown = actual_markdowns.first
-              expect(actual_markdown.message).to eq 'Some unknown message'
+              expect(actual_markdown.message).to eq 'Some unknown message [::PrivateConstant](https://github.com/MyOrg/my_repo/blob/my_branch/some/location.rb)'
               expect(actual_markdown.line).to eq 12
               expect(actual_markdown.file).to eq 'packs/referencing_pack/some_file.rb'
               expect(actual_markdown.type).to eq :markdown

--- a/spec/danger_packwerk/danger_packwerk_spec.rb
+++ b/spec/danger_packwerk/danger_packwerk_spec.rb
@@ -58,7 +58,7 @@ module DangerPackwerk
           Class.new do
             include Check::OffensesFormatter
 
-            def format_offenses(offenses, repo_link, org_name)
+            def format_offenses(offenses, repo_link, org_name, repo_url_builder: nil)
               offenses.map(&:message).join("\n\n")
             end
           end

--- a/spec/support/danger_plugin.rb
+++ b/spec/support/danger_plugin.rb
@@ -6,6 +6,7 @@ RSpec.shared_context 'danger plugin' do
   let(:renamed_files) { [] }
   let(:pr_json) do
     {
+      head: { ref: 'my_branch' },
       base: {
         repo: {
           html_url: 'https://github.com/MyOrg/my_repo',


### PR DESCRIPTION
Adds on a repo_link_builder argument to the OffenseFormatter in order to supply the formatter with the ability to create a repo link consistently.

This also changes the formatter links to use the HEAD of the branch instead of main, which is not available on every repository. 

This is an alternate implementation of #53.

Our goal in the alternate implementation was to avoid passing the entire `self` to the formatter. We thought that the html_link including anchor tags wasn't great, so we settled on a version that still constructs the url manually, but uses more information and allows for us to extend this in the future.