### PR TITLE
Add instructions for how to use additional violation types

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,18 @@ packwerk.check(
 )
 ```
 
+### Supporting new violation types
+By default, only `dependency` and `privacy` violation types are supported. If you wish to use other violation types you'll need to provide them when calling `check`:
+```ruby
+packwerk.check(
+  violation_types: %w[dependency privacy layer]
+)
+```
+
+Any violations not included in this list will be ignored.
+
+You will also most likely want to customize the offenses formatter and provide specific feedback for the new violation types.
+
 ## package_todo_yml_changes.check
 ![This is an image displaying an inline comment from the Danger github bot.](docs/update.png)
 


### PR DESCRIPTION
In my project I was adding feedback for the layer violation extension but I found that danger-packwerk would ignore the violations completely when testing.

After some digging I discovered there is a violation type allowlist that you need to configured. I think this would be helpful to list in the README so I've added a section. Let me know what you think 🙏 