### PR TITLE
Fix typos and grammatical issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 `danger-packwerk` integrates [`packwerk`](https://github.com/Shopify/packwerk) with [`danger`](https://github.com/danger/danger) to provide inline comments in PRs related to boundaries in a Rails application.
 
 ## Installation and Basic Usage
-Step 1: Add this line to your `Gemfile` (to whatever group your CI uses, as it is not needed in production) and `bundle install`:
+Step 1: Add this line to your `Gemfile` (to whatever group your CI uses, as it is not needed in production) and run `bundle install`:
 
 ```ruby
 gem 'danger-packwerk', group: :test
@@ -34,7 +34,7 @@ In upcoming iterations, we will include other danger checks, including:
 
 Without any configuration, `packwerk.check` should just work. By default, it will post a maximum of 15 messages in a PR and it will not fail the build.
 
-`packwerk.check` can be configured to in the following ways:
+`packwerk.check` can be configured in the following ways:
 
 ### Change the message that displays in the markdown
 To customize the message in the GitHub comment, pass in `offenses_formatter` to `packwerk.check` in your `Dangerfile`. Here's a simple example:
@@ -108,7 +108,7 @@ You will also most likely want to customize the offenses formatter and provide s
 
 Without any configuration, `package_todo_yml_changes.check` should just work. By default, it will post a maximum of 15 messages in a PR, using default messaging defined within this gem.
 
-`package_todo_yml_changes.check` can be configured to in the following ways:
+`package_todo_yml_changes.check` can be configured in the following ways:
 
 ### Change the message that displays in the markdown
 To customize the message in the GitHub comment, pass in `offenses_formatter` to `package_todo_yml_changes.check` in your `Dangerfile`. Here's a simple example:

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ In upcoming iterations, we will include other danger checks, including:
 
 ## packwerk.check
 ![This is an image displaying a comment from the Danger github bot after running bin/packwerk check.](docs/check_1.png)
-![This is an image displaying a comment from the Danger github bot after running bin/packwerk check with the "quick suggestions" accordian open](docs/check_2.png)
+![This is an image displaying a comment from the Danger github bot after running bin/packwerk check with the "quick suggestions" accordion open](docs/check_2.png)
 
 Without any configuration, `packwerk.check` should just work. By default, it will post a maximum of 15 messages in a PR and it will not fail the build.
 

--- a/lib/danger-packwerk/danger_packwerk.rb
+++ b/lib/danger-packwerk/danger_packwerk.rb
@@ -89,7 +89,7 @@ module DangerPackwerk
 
         # If a file has been modified via a rename, then `git.modified_files` will return an array that includes that file's *original* name.
         # Packwerk will ignore input files that do not exist, and when the PR only contains renamed Ruby files, that means packwerk check works
-        # off of an empty list. It's default behavior in that case is to scan *all* files, which can lead to abnormally long run times.
+        # off of an empty list. Its default behavior in that case is to scan *all* files, which can lead to abnormally long run times.
         # To avoid this, we gracefully return if there are no targeted files.
         # To avoid false negatives, we also look at renamed files after (above)
         file_exists = path.exist?

--- a/lib/danger-packwerk/danger_packwerk.rb
+++ b/lib/danger-packwerk/danger_packwerk.rb
@@ -67,7 +67,7 @@ module DangerPackwerk
       repo_url_builder = ->(constant_path) { "#{repo_link}/blob/#{github.pr_json[:head][:ref]}/#{constant_path}" }
       org_name = github.pr_json[:base][:repo][:owner][:login]
 
-      # This is important because by default, Danger will leave a concantenated list of all its messages if it can't find a commentable place in the
+      # This is important because by default, Danger will leave a concatenated list of all its messages if it can't find a commentable place in the
       # diff to leave its message. This is an especially bad UX because it will be a huge wall of text not connected to the source of the issue.
       # Furthermore, dismissing these ensures that something like moving a file from pack to pack does not trigger the danger message. That is,
       # the danger message will only be triggered by actual code that someone has actually written in their PR.


### PR DESCRIPTION
## Summary
- Fix typos: `accordian` → `accordion` in README, `concantenated` → `concatenated` in source comment
- Fix additional grammatical issues found in documentation and comments

## Changes
- Commit 1: Fix confirmed typos found by `typos` tool
- Commit 2: Additional grammar/prose improvements
  - README: add missing "run" before `bundle install` command
  - README: fix "configured to in" -> "configured in" (two occurrences)
  - `danger_packwerk.rb`: fix "It's" -> "Its" (possessive, not contraction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)