### PR TITLE
build(deps): bump rack-session to 2.1.2 (GHSA-33qg-7wpp-89cq)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -202,7 +202,7 @@ GEM
     public_suffix (6.0.1)
     racc (1.8.1)
     rack (3.1.12)
-    rack-session (2.1.0)
+    rack-session (2.1.2)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
     rack-test (2.2.0)


### PR DESCRIPTION
## What

Bumps the **transitive** `rack-session` dependency from `2.1.0` to `2.1.2` in `Gemfile.lock`.

## Why

Dependabot flagged a **critical** advisory: [GHSA-33qg-7wpp-89cq](https://github.com/advisories/GHSA-33qg-7wpp-89cq).

`Rack::Session::Cookie`'s decrypt-failure fallback enables secretless session forgery and Marshal deserialization. Vulnerable range: `>= 2.0.0, < 2.1.2`. The fix is to move to `2.1.2` or newer.

`rack-session` is not a direct Gemfile dependency here, so this is a lockfile-only change.

## How

```
bundle update rack-session --conservative
```

Diff is intentionally limited to the single `rack-session` version line.

## Verification (local, Ruby 3.2.2)

- `bundle install` clean
- `bundle exec rspec` → 67 examples, 0 failures
- `bundle exec rubocop` → 26 files inspected, no offenses
- `bundle exec srb tc` → No errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)