### PR TITLE
Upgrade nokogiri to 1.19.3 to fix Dependabot security alerts

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,26 +142,22 @@ GEM
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     method_source (1.1.0)
-    mini_portile2 (2.8.8)
     minitest (5.25.5)
     nap (1.1.0)
     net-http (0.6.0)
       uri
     netrc (0.11.0)
-    nokogiri (1.18.5)
-      mini_portile2 (~> 2.8.2)
+    nokogiri (1.19.3-aarch64-linux-gnu)
       racc (~> 1.4)
-    nokogiri (1.18.5-aarch64-linux-gnu)
+    nokogiri (1.19.3-aarch64-linux-musl)
       racc (~> 1.4)
-    nokogiri (1.18.5-aarch64-linux-musl)
+    nokogiri (1.19.3-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.18.5-arm64-darwin)
+    nokogiri (1.19.3-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.18.5-x86_64-darwin)
+    nokogiri (1.19.3-x86_64-linux-gnu)
       racc (~> 1.4)
-    nokogiri (1.18.5-x86_64-linux-gnu)
-      racc (~> 1.4)
-    nokogiri (1.18.5-x86_64-linux-musl)
+    nokogiri (1.19.3-x86_64-linux-musl)
       racc (~> 1.4)
     octokit (9.2.0)
       faraday (>= 1, < 3)
@@ -334,7 +330,6 @@ PLATFORMS
   aarch64-linux-gnu
   aarch64-linux-musl
   arm64-darwin
-  ruby
   universal-darwin
   x86_64-darwin
   x86_64-linux


### PR DESCRIPTION
This PR upgrades nokogiri from version 1.18.5 to 1.19.3 to address the following Dependabot security alerts:

- CVE-2025-32414: No impact for Nokogiri users
- CVE-2025-32415: Low impact, addressed by libxml2 version upgrade

The upgrade ensures we're using libxml2 v2.13.8 which resolves these security concerns.