### PR TITLE
fix(deps): Upgrade faraday gem for SSRF vulnerability (Build Exclusive URL)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in danger-packwerk.gemspec
 gemspec
 
-# Override the version of packwerk that is installed by the gemspec
+  gem 'faraday', '>= 2.14.2'
 gem 'packwerk', github: 'Shopify/packwerk', branch: 'main'
 
 # Development dependencies

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in danger-packwerk.gemspec
 gemspec
 
-  gem 'faraday', '>= 2.14.2'
+gem 'faraday', '>= 2.14.2'
 gem 'packwerk', github: 'Shopify/packwerk', branch: 'main'
 
 # Development dependencies

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,7 +133,7 @@ GEM
     drb (2.2.3)
     erb (6.0.4)
     erubi (1.13.1)
-    faraday (2.12.2)
+    faraday (2.14.3)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
@@ -376,6 +376,7 @@ PLATFORMS
 
 DEPENDENCIES
   danger-packwerk!
+  faraday (>= 2.14.2)
   packwerk!
   pry
   rack (>= 3.1.21)


### PR DESCRIPTION
This pull request updates the 'faraday' dependency from version <= 2.14.0 to >= 2.14.2. This change is critical as it mitigates a Server-Side Request Forgery (SSRF) vulnerability found in Faraday's build_exclusive_url method. The issue arises because protocol-relative URLs passed through Faraday's request methods can override the connection's base URL host, redirecting requests to an arbitrary external host controlled by an attacker. Upgrading resolves this security flaw entirely.