### PR TITLE
Add explicit GITHUB_TOKEN permissions to workflows

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -8,5 +8,7 @@ on:
 
 jobs:
   call-workflow-from-shared-config:
+    permissions:
+      contents: write
     uses: rubyatscale/shared-config/.github/workflows/cd.yml@main
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   run_tests:
     runs-on: ubuntu-latest
@@ -53,6 +56,7 @@ jobs:
         run: bundle exec rubocop
   notify_on_failure:
     runs-on: ubuntu-latest
+    permissions: {}
     needs: [run_tests, static_type_check, run_linter]
     if: ${{ failure() && github.ref == 'refs/heads/main' }}
     env:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,4 +5,7 @@ on:
     - cron: '0 0 * * *'
 jobs:
   call-workflow-from-shared-config:
+    permissions:
+      issues: write
+      pull-requests: write
     uses: rubyatscale/shared-config/.github/workflows/stale.yml@main

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -6,4 +6,6 @@ on:
       - opened
 jobs:
   call-workflow-from-shared-config:
+    permissions:
+      issues: write
     uses: rubyatscale/shared-config/.github/workflows/triage.yml@main


### PR DESCRIPTION
Resolves the seven open CodeQL actions/missing-workflow-permissions
alerts (#1, #3, #4, #5, #6, #7, #8) by declaring the least privilege
each job actually needs.

ci.yml: one workflow-level `contents: read` covers run_tests,
static_type_check and run_linter -- each only checks out the repo and
runs rspec / srb tc / rubocop. notify_on_failure gets a job-level
`permissions: {}`: it never checks out and posts to Slack through an
incoming webhook secret, so it needs no GitHub token scopes at all.

cd.yml: `contents: write` -- shared-config's cd.yml checks out with
persisted credentials, runs publish-rubygems-action (rake release does a
raw git push of the version tag) and then `gh release create`.

stale.yml: `issues: write` + `pull-requests: write` -- actions/stale
comments on and closes both stale issues and stale PRs.

triage.yml: `issues: write` -- the called workflow runs
`gh issue edit --add-label triage`.

A caller's permissions block is the ceiling for the reusable workflow it
calls, so these grants match what shared-config needs rather than being
clamped to read-only.


### Alerts resolved

- [#8](https://github.com/rubyatscale/danger-packwerk/security/code-scanning/8) `actions/missing-workflow-permissions` (medium) — `.github/workflows/ci.yml:11`
- [#7](https://github.com/rubyatscale/danger-packwerk/security/code-scanning/7) `actions/missing-workflow-permissions` (medium) — `.github/workflows/ci.yml:55`
- [#6](https://github.com/rubyatscale/danger-packwerk/security/code-scanning/6) `actions/missing-workflow-permissions` (medium) — `.github/workflows/ci.yml:43`
- [#5](https://github.com/rubyatscale/danger-packwerk/security/code-scanning/5) `actions/missing-workflow-permissions` (medium) — `.github/workflows/ci.yml:31`
- [#4](https://github.com/rubyatscale/danger-packwerk/security/code-scanning/4) `actions/missing-workflow-permissions` (medium) — `.github/workflows/cd.yml:11`
- [#3](https://github.com/rubyatscale/danger-packwerk/security/code-scanning/3) `actions/missing-workflow-permissions` (medium) — `.github/workflows/triage.yml:9`
- [#1](https://github.com/rubyatscale/danger-packwerk/security/code-scanning/1) `actions/missing-workflow-permissions` (medium) — `.github/workflows/stale.yml:8`

### Verification

- Every job in every flagged workflow now has an effective `permissions:` block (cross-checked by parsing the YAML against the alert list).
- `actionlint` output is byte-identical to `main` — no new findings introduced.
- `codeql.yml` untouched.
